### PR TITLE
Fix null handling in stream serialization

### DIFF
--- a/src/ToJsonExtensions/ToJsonExtensions.cs
+++ b/src/ToJsonExtensions/ToJsonExtensions.cs
@@ -11,7 +11,7 @@ public static class JsonExtensions
     /// </summary>
     /// <param name="obj">The object to serialize.</param>
     /// <param name="indented">Whether to indent the JSON output (default: false).</param>
-    /// <param name="namingPolicy">The naming policy to apply (default: camelCase).</param>
+    /// <param name="namingPolicy">The naming policy to apply (default: none).</param>
     /// <returns>A JSON-formatted string.</returns>
     public static string ToJsonString(this object? obj, bool indented = false, JsonNamingPolicy? namingPolicy = null)
     {
@@ -33,8 +33,8 @@ public static class JsonExtensions
     /// <param name="obj">The object to serialize.</param>
     /// <param name="stream">The target stream to write JSON to.</param>
     /// <param name="indented">Whether to indent the JSON output (default: false).</param>
-    /// <param name="namingPolicy">The naming policy to apply (default: camelCase).</param>
-    public static async Task ToJsonStreamAsync(this object obj, Stream stream, bool indented = false, JsonNamingPolicy? namingPolicy = null)
+    /// <param name="namingPolicy">The naming policy to apply (default: none).</param>
+    public static async Task ToJsonStreamAsync(this object? obj, Stream stream, bool indented = false, JsonNamingPolicy? namingPolicy = null)
     {
         var options = new JsonSerializerOptions
         {
@@ -42,7 +42,14 @@ public static class JsonExtensions
             PropertyNamingPolicy = namingPolicy
         };
 
-        await JsonSerializer.SerializeAsync(stream, obj, obj.GetType(), options);
+        if (obj is null)
+        {
+            await JsonSerializer.SerializeAsync<object?>(stream, null, options);
+        }
+        else
+        {
+            await JsonSerializer.SerializeAsync(stream, obj, obj.GetType(), options);
+        }
     }
 
     /// <summary>
@@ -51,7 +58,7 @@ public static class JsonExtensions
     /// <param name="obj">The object to serialize.</param>
     /// <param name="path">The full file path to write to.</param>
     /// <param name="indented">Whether to indent the JSON output (default: false).</param>
-    /// <param name="namingPolicy">The naming policy to apply (default: camelCase).</param>
+    /// <param name="namingPolicy">The naming policy to apply (default: none).</param>
     public static async Task ToJsonFileAsync(this object obj, string path, bool indented = false, JsonNamingPolicy? namingPolicy = null)
     {
         using var stream = File.Create(path);
@@ -64,7 +71,7 @@ public static class JsonExtensions
     /// <param name="obj">The object to serialize.</param>
     /// <param name="path">The full file path to write to.</param>
     /// <param name="indented">Whether to indent the JSON output (default: false).</param>
-    /// <param name="namingPolicy">The naming policy to apply (default: camelCase).</param>
+    /// <param name="namingPolicy">The naming policy to apply (default: none).</param>
     public static void ToJsonFile(this object obj, string path, bool indented = false, JsonNamingPolicy? namingPolicy = null)
     {
         var json = obj.ToJsonString(indented, namingPolicy);

--- a/src/ToJsonExtensionsTest/ToJsonExtensionsTest.cs
+++ b/src/ToJsonExtensionsTest/ToJsonExtensionsTest.cs
@@ -75,4 +75,15 @@ public class JsonExtensionsTests
         Assert.Contains("FirstName", json); // Skal være med stort F
         Assert.Contains("50", json);
     }
+
+    [Fact]
+    public async Task ToJsonStreamAsync_WithNullObject_WritesNull()
+    {
+        using var stream = new MemoryStream();
+        await JsonExtensions.ToJsonStreamAsync((object?)null, stream);
+        stream.Position = 0;
+        using var reader = new StreamReader(stream);
+        string result = reader.ReadToEnd();
+        Assert.Equal("null", result);
+    }
 }


### PR DESCRIPTION
## Summary
- handle null objects in `ToJsonStreamAsync`
- clarify comment docs
- test null support

## Testing
- `dotnet test src/ToJsonExtensionsTest/ToJsonExtensionsTest.csproj --no-build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_684134bb2c6c832283b005a1fef7e94c